### PR TITLE
Record relation id of sequential scan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 build/
 .vscode
 
-/target
-/tmp_install
+target/
+tmp_install/
+data/

--- a/postgres/contrib/remotexact/remotexact.c
+++ b/postgres/contrib/remotexact/remotexact.c
@@ -81,7 +81,7 @@ rx_collect_seq_scan_rel_id(Relation relation) {
 }
 
 static void
-rx_collect_scan_page_id(Relation relation, BlockNumber blkno) {
+rx_collect_index_scan_page_id(Relation relation, BlockNumber blkno) {
 	StringInfo buf = NULL;
 
 	if (CurrentReadWriteSet == NULL)
@@ -178,7 +178,7 @@ static const RemoteXactHook remote_xact_hook =
 {
 	.collect_read_tid = rx_collect_read_tid,
 	.collect_seq_scan_rel_id = rx_collect_seq_scan_rel_id,
-	.collect_scan_page_id = rx_collect_scan_page_id,
+	.collect_index_scan_page_id = rx_collect_index_scan_page_id,
 	.clear_rwset = rx_clear_rwset,
 	.send_rwset_and_wait = rx_send_rwset_and_wait
 };

--- a/postgres/contrib/remotexact/remotexact.c
+++ b/postgres/contrib/remotexact/remotexact.c
@@ -66,7 +66,7 @@ rx_collect_read_tid(Relation relation, ItemPointer tid, TransactionId tuple_xid)
 }
 
 static void
-rx_collect_scan_rel_id(Relation relation) {
+rx_collect_seq_scan_rel_id(Relation relation) {
 	StringInfo buf = NULL;
 
 	if (CurrentReadWriteSet == NULL)
@@ -177,7 +177,7 @@ rx_send_rwset_and_wait(void)
 static const RemoteXactHook remote_xact_hook =
 {
 	.collect_read_tid = rx_collect_read_tid,
-	.collect_scan_rel_id = rx_collect_scan_rel_id,
+	.collect_seq_scan_rel_id = rx_collect_seq_scan_rel_id,
 	.collect_scan_page_id = rx_collect_scan_page_id,
 	.clear_rwset = rx_clear_rwset,
 	.send_rwset_and_wait = rx_send_rwset_and_wait

--- a/postgres/contrib/remotexact/remotexact.c
+++ b/postgres/contrib/remotexact/remotexact.c
@@ -66,6 +66,21 @@ rx_collect_read_tid(Relation relation, ItemPointer tid, TransactionId tuple_xid)
 }
 
 static void
+rx_collect_scan_rel_id(Relation relation) {
+	StringInfo buf = NULL;
+
+	if (CurrentReadWriteSet == NULL)
+		init_read_write_set();
+
+	buf = &(CurrentReadWriteSet->buf);
+	
+	pq_sendint32(buf, relation->rd_node.dbNode);
+	pq_sendint32(buf, relation->rd_id);
+	pq_sendint32(buf, -1);
+	pq_sendint16(buf, -1);
+}
+
+static void
 rx_clear_rwset(void)
 {
 	if (CurrentReadWriteSet == NULL)
@@ -147,6 +162,7 @@ rx_send_rwset_and_wait(void)
 static const RemoteXactHook remote_xact_hook =
 {
 	.collect_read_tid = rx_collect_read_tid,
+	.collect_scan_rel_id = rx_collect_scan_rel_id,
 	.clear_rwset = rx_clear_rwset,
 	.send_rwset_and_wait = rx_send_rwset_and_wait
 };

--- a/postgres/contrib/remotexact/remotexact.c
+++ b/postgres/contrib/remotexact/remotexact.c
@@ -81,6 +81,21 @@ rx_collect_scan_rel_id(Relation relation) {
 }
 
 static void
+rx_collect_scan_page_id(Relation relation, BlockNumber blkno) {
+	StringInfo buf = NULL;
+
+	if (CurrentReadWriteSet == NULL)
+		init_read_write_set();
+
+	buf = &(CurrentReadWriteSet->buf);
+	
+	pq_sendint32(buf, relation->rd_node.dbNode);
+	pq_sendint32(buf, relation->rd_id);
+	pq_sendint32(buf, blkno);
+	pq_sendint16(buf, -1);
+}
+
+static void
 rx_clear_rwset(void)
 {
 	if (CurrentReadWriteSet == NULL)
@@ -163,6 +178,7 @@ static const RemoteXactHook remote_xact_hook =
 {
 	.collect_read_tid = rx_collect_read_tid,
 	.collect_scan_rel_id = rx_collect_scan_rel_id,
+	.collect_scan_page_id = rx_collect_scan_page_id,
 	.clear_rwset = rx_clear_rwset,
 	.send_rwset_and_wait = rx_send_rwset_and_wait
 };

--- a/postgres/src/backend/access/transam/remotexact_default.c
+++ b/postgres/src/backend/access/transam/remotexact_default.c
@@ -16,6 +16,11 @@ default_collect_read_tid(Relation relation, ItemPointer tid, TransactionId tuple
 }
 
 static void
+default_collect_scan_rel_id(Relation relation)
+{
+}
+
+static void
 default_clear_rwset(void)
 {
 }
@@ -27,6 +32,7 @@ default_send_rwset_and_wait(void)
 
 static const RemoteXactHook default_hook = {
 	.collect_read_tid = default_collect_read_tid,
+	.collect_scan_rel_id = default_collect_scan_rel_id,
 	.clear_rwset = default_clear_rwset,
 	.send_rwset_and_wait = default_send_rwset_and_wait
 };

--- a/postgres/src/backend/access/transam/remotexact_default.c
+++ b/postgres/src/backend/access/transam/remotexact_default.c
@@ -21,7 +21,7 @@ default_collect_seq_scan_rel_id(Relation relation)
 }
 
 static void 
-default_collect_scan_page_id(Relation relation, BlockNumber blkno)
+default_collect_index_scan_page_id(Relation relation, BlockNumber blkno)
 {
 }
 
@@ -38,7 +38,7 @@ default_send_rwset_and_wait(void)
 static const RemoteXactHook default_hook = {
 	.collect_read_tid = default_collect_read_tid,
 	.collect_seq_scan_rel_id = default_collect_seq_scan_rel_id,
-	.collect_scan_page_id = default_collect_scan_page_id,
+	.collect_index_scan_page_id = default_collect_index_scan_page_id,
 	.clear_rwset = default_clear_rwset,
 	.send_rwset_and_wait = default_send_rwset_and_wait
 };

--- a/postgres/src/backend/access/transam/remotexact_default.c
+++ b/postgres/src/backend/access/transam/remotexact_default.c
@@ -20,6 +20,11 @@ default_collect_scan_rel_id(Relation relation)
 {
 }
 
+static void 
+default_collect_scan_page_id(Relation relation, BlockNumber blkno)
+{
+}
+
 static void
 default_clear_rwset(void)
 {
@@ -33,6 +38,7 @@ default_send_rwset_and_wait(void)
 static const RemoteXactHook default_hook = {
 	.collect_read_tid = default_collect_read_tid,
 	.collect_scan_rel_id = default_collect_scan_rel_id,
+	.collect_scan_page_id = default_collect_scan_page_id,
 	.clear_rwset = default_clear_rwset,
 	.send_rwset_and_wait = default_send_rwset_and_wait
 };

--- a/postgres/src/backend/access/transam/remotexact_default.c
+++ b/postgres/src/backend/access/transam/remotexact_default.c
@@ -16,7 +16,7 @@ default_collect_read_tid(Relation relation, ItemPointer tid, TransactionId tuple
 }
 
 static void
-default_collect_scan_rel_id(Relation relation)
+default_collect_seq_scan_rel_id(Relation relation)
 {
 }
 
@@ -37,7 +37,7 @@ default_send_rwset_and_wait(void)
 
 static const RemoteXactHook default_hook = {
 	.collect_read_tid = default_collect_read_tid,
-	.collect_scan_rel_id = default_collect_scan_rel_id,
+	.collect_seq_scan_rel_id = default_collect_seq_scan_rel_id,
 	.collect_scan_page_id = default_collect_scan_page_id,
 	.clear_rwset = default_clear_rwset,
 	.send_rwset_and_wait = default_send_rwset_and_wait

--- a/postgres/src/backend/storage/lmgr/predicate.c
+++ b/postgres/src/backend/storage/lmgr/predicate.c
@@ -2605,7 +2605,7 @@ PredicateLockPage(Relation relation, BlockNumber blkno, Snapshot snapshot)
 									blkno);
 	PredicateLockAcquire(&tag);
 
-	GetRemoteXactHook()->collect_scan_page_id(relation, blkno);
+	GetRemoteXactHook()->collect_index_scan_page_id(relation, blkno);
 }
 
 /*

--- a/postgres/src/backend/storage/lmgr/predicate.c
+++ b/postgres/src/backend/storage/lmgr/predicate.c
@@ -2578,6 +2578,8 @@ PredicateLockRelation(Relation relation, Snapshot snapshot)
 										relation->rd_node.dbNode,
 										relation->rd_id);
 	PredicateLockAcquire(&tag);
+
+	GetRemoteXactHook()->collect_scan_rel_id(relation);
 }
 
 /*

--- a/postgres/src/backend/storage/lmgr/predicate.c
+++ b/postgres/src/backend/storage/lmgr/predicate.c
@@ -2604,6 +2604,8 @@ PredicateLockPage(Relation relation, BlockNumber blkno, Snapshot snapshot)
 									relation->rd_id,
 									blkno);
 	PredicateLockAcquire(&tag);
+
+	GetRemoteXactHook()->collect_scan_page_id(relation, blkno);
 }
 
 /*

--- a/postgres/src/backend/storage/lmgr/predicate.c
+++ b/postgres/src/backend/storage/lmgr/predicate.c
@@ -2579,7 +2579,7 @@ PredicateLockRelation(Relation relation, Snapshot snapshot)
 										relation->rd_id);
 	PredicateLockAcquire(&tag);
 
-	GetRemoteXactHook()->collect_scan_rel_id(relation);
+	GetRemoteXactHook()->collect_seq_scan_rel_id(relation);
 }
 
 /*

--- a/postgres/src/include/access/remotexact.h
+++ b/postgres/src/include/access/remotexact.h
@@ -16,6 +16,7 @@ typedef struct
 {
 	void		(*collect_read_tid) (Relation relation, ItemPointer tid, TransactionId tuple_xid);
 	void		(*collect_scan_rel_id) (Relation relation);
+	void 		(*collect_scan_page_id) (Relation relation, BlockNumber blkno);
 	void		(*clear_rwset) (void);
 	void		(*send_rwset_and_wait) (void);
 } RemoteXactHook;

--- a/postgres/src/include/access/remotexact.h
+++ b/postgres/src/include/access/remotexact.h
@@ -15,6 +15,7 @@
 typedef struct
 {
 	void		(*collect_read_tid) (Relation relation, ItemPointer tid, TransactionId tuple_xid);
+	void		(*collect_scan_rel_id) (Relation relation);
 	void		(*clear_rwset) (void);
 	void		(*send_rwset_and_wait) (void);
 } RemoteXactHook;

--- a/postgres/src/include/access/remotexact.h
+++ b/postgres/src/include/access/remotexact.h
@@ -16,7 +16,7 @@ typedef struct
 {
 	void		(*collect_read_tid) (Relation relation, ItemPointer tid, TransactionId tuple_xid);
 	void		(*collect_seq_scan_rel_id) (Relation relation);
-	void 		(*collect_scan_page_id) (Relation relation, BlockNumber blkno);
+	void 		(*collect_index_scan_page_id) (Relation relation, BlockNumber blkno);
 	void		(*clear_rwset) (void);
 	void		(*send_rwset_and_wait) (void);
 } RemoteXactHook;

--- a/postgres/src/include/access/remotexact.h
+++ b/postgres/src/include/access/remotexact.h
@@ -15,7 +15,7 @@
 typedef struct
 {
 	void		(*collect_read_tid) (Relation relation, ItemPointer tid, TransactionId tuple_xid);
-	void		(*collect_scan_rel_id) (Relation relation);
+	void		(*collect_seq_scan_rel_id) (Relation relation);
 	void 		(*collect_scan_page_id) (Relation relation, BlockNumber blkno);
 	void		(*clear_rwset) (void);
 	void		(*send_rwset_and_wait) (void);


### PR DESCRIPTION
Add some simple changes to 
1. record the relation id of sequential scan
2. record the page id of index scan

I did not add new formats in the buffer. Instead I reused the existing one for tuples, and simply used `-1` for the block and offset number when they are not needed.
 
# How to build

* To build, simply call `make` at the root directory.
* Start the transaction server: `target/debug/xactserver`. Run the next steps in another terminal.
* Set PGDATA to where you want to keep the databases, for example: `export PGDATA=$PWD/data/postgresql`.
* Initialize a database cluster: `tmp_install/bin/initdb`.
* Start postgres: `tmp_install/bin/postgres`.
* Use `psql` to connect to the postgres server: `psql -d postgres`.

# How to test
### Sequential Scan
```
load 'remotexact';
create table tbl(a int, b int);
insert into tbl values(1, 10);
insert into tbl values(2, 20);
insert into tbl values(3, 20);
insert into tbl values(4, 20);
begin transaction isolation level serializable;
select * from tbl;
commit;
```
The terminal of the transaction server should show something like this:
```
Listening on port 8888
new connection created
(12755, 24576, -1, -1)
```

If you want to test on a relation that already have indexes. Then you need to tell the query optimizer disable the corresponding index scans before running a transaction. 
```
set enable_indexscan=off;
set enable_bitmapscan=off;
...
```
### Index Scan
```
load 'remotexact';
create index on tbl (b);
set enable_seqscan=off;
begin transaction isolation level serializable;
select * from tbl where b=20;
commit;
```
The terminal of the transaction server should show something like this:
```
Listening on port 8888
new connection created
(12755, 24580, 1, -1)
(12755, 24576, 0, 2)
(12755, 24576, 0, 3)
(12755, 24576, 0, 4)
```