### PR TITLE
Create LocalLogManager and connect to PgWatcher

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -394,9 +394,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "399c583b2979440c60be0821a6199eca73bc3c8dcd9d070d75ac726e2c6186e5"
+checksum = "1ff4f84919677303da5f147645dbea6b1881f368d03ac84e1dc09031ebd7b2c6"
 dependencies = [
  "bytes",
  "http",
@@ -423,9 +423,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.13"
+version = "0.14.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15d1cfb9e4f68655fa04c01f59edb405b6074a0f7118ea881e5026e4a1cd8593"
+checksum = "2b91bb1f221b6ea1f1e4371216b70f40748774c2fb5971b450c07773fb92d26b"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -608,6 +608,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -1147,8 +1157,21 @@ dependencies = [
  "libc",
  "memchr",
  "mio",
+ "num_cpus",
  "pin-project-lite",
+ "tokio-macros",
  "winapi",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "114383b041aa6212c579467afa0075fbbdd0718de036100bc0ba7961d8cb9095"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1472,6 +1495,7 @@ dependencies = [
  "clap",
  "env_logger",
  "log",
+ "tokio",
  "zenith_utils",
 ]
 

--- a/xactserver/Cargo.toml
+++ b/xactserver/Cargo.toml
@@ -9,4 +9,5 @@ bytes = { version = "1.0.1", features = ['serde'] }
 clap = "2.33.0"
 env_logger = "0.9.0"
 log = "0.4.14"
+tokio = { version = "1.0", features = ["rt-multi-thread", "macros", "sync"] }
 zenith_utils = { git = "https://github.com/zenithdb/zenith.git", package = "zenith_utils" }

--- a/xactserver/src/bin/xactserver.rs
+++ b/xactserver/src/bin/xactserver.rs
@@ -1,11 +1,10 @@
 use clap::{App, Arg};
 use std::thread;
-use xactserver::PgWatcher;
+use tokio::sync::mpsc;
+use xactserver::{LocalLogManager, PgWatcher};
 
 fn main() -> anyhow::Result<()> {
-    env_logger::Builder::from_env(
-        env_logger::Env::default().default_filter_or("info")
-    ).init();
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
 
     let args = App::new("Transaction server")
         .about("Manage the transaction logs")
@@ -19,13 +18,31 @@ fn main() -> anyhow::Result<()> {
 
     let listen_pg = String::from(args.value_of("listen-pg").unwrap_or("127.0.0.1:8888"));
 
-    let pg_watcher = PgWatcher::new(&listen_pg);
+    // Create local log manager
+    let local_log_man = LocalLogManager::new();
 
-    thread::Builder::new()
-        .name("postgres watcher".into())
-        .spawn(move || pg_watcher.thread_main())?
-        .join()
-        .unwrap()?;
+    // Create a channel for sending txn from the postgres watcher
+    // to the local log manager
+    let (local_log_tx, local_log_rx) = mpsc::channel(32);
+    let pg_watcher = PgWatcher::new(&listen_pg, local_log_tx);
+
+    let mut join_handles = Vec::new();
+
+    join_handles.push(
+        thread::Builder::new()
+            .name("postgres watcher".into())
+            .spawn(move || pg_watcher.thread_main())?,
+    );
+
+    join_handles.push(
+        thread::Builder::new()
+            .name("local log manager".into())
+            .spawn(move || local_log_man.thread_main(local_log_rx))?,
+    );
+
+    for handle in join_handles {
+        handle.join().unwrap()?;
+    }
 
     Ok(())
 }

--- a/xactserver/src/lib.rs
+++ b/xactserver/src/lib.rs
@@ -1,2 +1,5 @@
 mod pg_watch;
 pub use crate::pg_watch::PgWatcher;
+
+mod local_log;
+pub use crate::local_log::LocalLogManager;

--- a/xactserver/src/local_log.rs
+++ b/xactserver/src/local_log.rs
@@ -1,0 +1,68 @@
+use bytes::{Buf, Bytes};
+use std::sync::{Arc, Mutex};
+use tokio::sync::mpsc;
+
+/// A `LocalLogManager` receives transactions from the postgres backends in the [`PgWatcher`]
+/// and appends them to the local log.
+///
+/// [`PgWatcher`]: crate::PgWatcher
+///
+pub struct LocalLogManager {
+    xact_log: Arc<Mutex<XactLog>>,
+}
+
+impl LocalLogManager {
+    pub fn new() -> LocalLogManager {
+        LocalLogManager {
+            xact_log: Arc::new(Mutex::new(XactLog::new())),
+        }
+    }
+
+    pub fn thread_main(&self, mut local_log_rx: mpsc::Receiver<Bytes>) -> anyhow::Result<()> {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .unwrap();
+
+        let xact_log = Arc::clone(&self.xact_log);
+        rt.block_on(async move {
+            while let Some(mut buf) = local_log_rx.recv().await {
+                // TODO: The xact_log is wrapped in a mutex because it will be shared by
+                // different asynchronous tasks responsible for log replication
+                let mut log = xact_log.lock().unwrap();
+                log.append(buf.to_vec());
+
+                while let Some(tup) = get_tuple(&mut buf) {
+                    println!("{:?}", tup);
+                }
+            }
+        });
+
+        Ok(())
+    }
+}
+
+struct XactLog {
+    log: Vec<Vec<u8>>,
+}
+
+impl XactLog {
+    pub fn new() -> XactLog {
+        XactLog { log: Vec::new() }
+    }
+
+    pub fn append(&mut self, entry: Vec<u8>) {
+        self.log.push(entry)
+    }
+}
+
+fn get_tuple(buf: &mut Bytes) -> Option<(i32, i32, i32, i16)> {
+    if buf.remaining() == 0 {
+        return None;
+    }
+    let dbid = buf.get_i32();
+    let rid = buf.get_i32();
+    let blockno = buf.get_i32();
+    let offset = buf.get_i16();
+
+    Some((dbid, rid, blockno, offset))
+}


### PR DESCRIPTION
Create a `LocalLogManager` that is responsible for appending the transaction data to the local log. The transaction is sent from the `PgWatcher` to the `LocalLogManager` via a channel.

The `LocalLogManager` runs in an async runtime because it will also contain a subscription server later. It uses a single thread now but that can be easily changed if needed.

Testing this change can be done similar to https://github.com/poojanilangekar/Slogora/pull/2. Notice that it is the `LocalLogManager` that prints out the tuples now, not the `PgWatcher`.

