### PR TITLE
Create RemoteLogsManager that subscribes to logs of other nodes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,6 +36,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61604a8f862e1d5c3229fdd78f8b02c68dcf73a4c4b05fd636d12240aaa242c1"
 
 [[package]]
+name = "async-stream"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "171374e7e3b2504e0e5236e3b59260560f9fe94bfe9ac39ba5e4e929c5590625"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "648ed8c8d2ce5409ccd57453d9d1b214b342a0d69376a6feda1fd6cae3299308"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -189,6 +210,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+
+[[package]]
 name = "env_logger"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -206,6 +233,12 @@ name = "fallible-iterator"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "398ea4fabe40b9b0d885340a2a991a44c8a645624075ad966d21f88688e2b69e"
 
 [[package]]
 name = "fnv"
@@ -354,6 +387,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 
 [[package]]
+name = "heck"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -446,6 +488,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-timeout"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
+dependencies = [
+ "hyper",
+ "pin-project-lite",
+ "tokio",
+ "tokio-io-timeout",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -462,6 +516,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69ddb889f9d0d08a67338271fa9b62996bc788c7796a5c18cf057420aaed5eaf"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -572,6 +635,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "multimap"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
+
+[[package]]
 name = "ntapi"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -675,6 +744,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
+name = "petgraph"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a13a2fa9d0b63e5f22328828741e523766fff0ee9e779316902290dff3f824f"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
+]
+
+[[package]]
 name = "phf"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -690,6 +769,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c00cf8b9eafe68dde5e9eaa2cef8ee84a9336a47d566ec55ca16589633b65af7"
 dependencies = [
  "siphasher",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "576bc800220cc65dac09e99e97b08b358cfab6e17078de8dc5fee223bd2d0c08"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e8fe8163d14ce7f0cdac2e040116f22eac817edabff0be91e8aff7e9accf389"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -788,6 +887,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "444879275cb4fd84958b1a1d5420d15e6fcf7c235fe47f053c9c2a80aceb6001"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62941722fb675d463659e49c4f3fe1fe792ff24fe5bbaa9c08cd3b98a1c354f5"
+dependencies = [
+ "bytes",
+ "heck",
+ "itertools",
+ "lazy_static",
+ "log",
+ "multimap",
+ "petgraph",
+ "prost",
+ "prost-types",
+ "regex",
+ "tempfile",
+ "which",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9cc1a3263e07e0bf68e96268f37665207b49560d98739662cdfaae215c720fe"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "534b7a0e836e3c482d2693070f982e39e7611da9695d4d1f5a4b186b51faef0a"
+dependencies = [
+ "bytes",
+ "prost",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -870,6 +1022,15 @@ name = "regex-syntax"
 version = "0.6.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+
+[[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "ring"
@@ -1075,6 +1236,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "rand",
+ "redox_syscall",
+ "remove_dir_all",
+ "winapi",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1164,6 +1339,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-io-timeout"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90c49f106be240de154571dd31fbe48acb10ba6c6dd6f6517ad603abffa42de9"
+dependencies = [
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-macros"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1197,6 +1382,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-stream"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50145484efff8818b5ccd256697f36863f587da82cf8b409c53adf1e840798e3"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1211,6 +1407,76 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24203b79cf2d68909da91178db3026e77054effba0c5d93deb870d3ca7b35afa"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "base64 0.13.0",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-timeout",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "prost-derive",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+ "tracing-futures",
+]
+
+[[package]]
+name = "tonic-build"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88358bb1dcfeb62dcce85c63006cafb964b7be481d522b7e09589d4d1e718d2a"
+dependencies = [
+ "proc-macro2",
+ "prost-build",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tower"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c00e500fff5fa1131c866b246041a6bf96da9c965f8fe4128cb1421f23e93c00"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "indexmap",
+ "pin-project",
+ "pin-project-lite",
+ "rand",
+ "slab",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "343bc9466d3fe6b0f960ef45960509f84480bf4fd96f92901afe7ff3df9d3a62"
+
+[[package]]
 name = "tower-service"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1223,6 +1489,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "375a639232caf30edfc78e8d89b2d4c375515393e7af7e16f01cd96917fb2105"
 dependencies = [
  "cfg-if",
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -1246,6 +1513,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f4ed65637b8390770814083d20756f87bfa2c21bf2f110babdc5438351746e4"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "tracing-futures"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
+dependencies = [
+ "pin-project",
+ "tracing",
 ]
 
 [[package]]
@@ -1317,6 +1594,12 @@ checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
 
 [[package]]
 name = "unicode-width"
@@ -1439,6 +1722,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "4.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea187a8ef279bc014ec368c27a920da2024d2a711109bfbe3440585d5cf27ad9"
+dependencies = [
+ "either",
+ "lazy_static",
+ "libc",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1494,8 +1788,13 @@ dependencies = [
  "bytes",
  "clap",
  "env_logger",
+ "futures",
  "log",
+ "prost",
  "tokio",
+ "tokio-stream",
+ "tonic",
+ "tonic-build",
  "zenith_utils",
 ]
 

--- a/xactserver/Cargo.toml
+++ b/xactserver/Cargo.toml
@@ -8,6 +8,13 @@ anyhow = "1.0"
 bytes = { version = "1.0.1", features = ['serde'] }
 clap = "2.33.0"
 env_logger = "0.9.0"
+futures = "0.3.17"
 log = "0.4.14"
+prost = "0.9"
+tonic = "0.6"
 tokio = { version = "1.0", features = ["rt-multi-thread", "macros", "sync"] }
+tokio-stream = "0.1"
 zenith_utils = { git = "https://github.com/zenithdb/zenith.git", package = "zenith_utils" }
+
+[build-dependencies]
+tonic-build = "0.6"

--- a/xactserver/build.rs
+++ b/xactserver/build.rs
@@ -1,0 +1,4 @@
+fn main() {
+    tonic_build::compile_protos("proto/log_replication.proto")
+        .unwrap_or_else(|e| panic!("Failed to compile proto {:?}", e));
+}

--- a/xactserver/proto/log_replication.proto
+++ b/xactserver/proto/log_replication.proto
@@ -1,0 +1,14 @@
+syntax = "proto3";
+
+package xactserver;
+
+service LogReplication {
+  rpc Subscribe(Subscription) returns (stream LogEntry) {}
+}
+
+message Subscription {
+}
+
+message LogEntry {
+  bytes data = 1;
+}

--- a/xactserver/src/bin/xactserver.rs
+++ b/xactserver/src/bin/xactserver.rs
@@ -1,7 +1,7 @@
 use clap::{App, Arg};
 use std::thread;
 use tokio::sync::mpsc;
-use xactserver::{LocalLogManager, PgWatcher};
+use xactserver::{LocalLogManager, PgWatcher, RemoteLogsManager};
 
 fn main() -> anyhow::Result<()> {
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
@@ -14,17 +14,32 @@ fn main() -> anyhow::Result<()> {
                 .takes_value(true)
                 .help("ip:port to listen to for local transactions from a PostgreSQL instance"),
         )
+        .arg(
+            Arg::with_name("listen-peer")
+                .long("listen-peer")
+                .takes_value(true)
+                .help("ip:port to listen to for connection from other peer servers"),
+        )
+        .arg(
+            Arg::with_name("peers")
+                .long("peers")
+                .use_delimiter(true)
+                .takes_value(true),
+        )
         .get_matches();
 
-    let listen_pg = String::from(args.value_of("listen-pg").unwrap_or("127.0.0.1:8888"));
+    let listen_pg = args.value_of("listen-pg").unwrap_or("127.0.0.1:8888");
+    let listen_peer = args.value_of("listen-peer").unwrap_or("127.0.0.1:10000");
+    let peers = args.values_of("peers").unwrap_or_default().collect();
 
-    // Create local log manager
-    let local_log_man = LocalLogManager::new();
+    // Create log managers
+    let local_log_man = LocalLogManager::new(listen_peer);
+    let remote_logs_man = RemoteLogsManager::new(peers);
 
-    // Create a channel for sending txn from the postgres watcher
+    // Create a postgres watcher with a channel for sending txn
     // to the local log manager
-    let (local_log_tx, local_log_rx) = mpsc::channel(32);
-    let pg_watcher = PgWatcher::new(&listen_pg, local_log_tx);
+    let (local_log_tx, local_log_rx) = mpsc::channel(100);
+    let pg_watcher = PgWatcher::new(listen_pg, local_log_tx);
 
     let mut join_handles = Vec::new();
 
@@ -38,6 +53,12 @@ fn main() -> anyhow::Result<()> {
         thread::Builder::new()
             .name("local log manager".into())
             .spawn(move || local_log_man.thread_main(local_log_rx))?,
+    );
+
+    join_handles.push(
+        thread::Builder::new()
+            .name("remote logs manager".into())
+            .spawn(move || remote_logs_man.thread_main())?,
     );
 
     for handle in join_handles {

--- a/xactserver/src/lib.rs
+++ b/xactserver/src/lib.rs
@@ -3,3 +3,6 @@ pub use crate::pg_watch::PgWatcher;
 
 mod local_log;
 pub use crate::local_log::LocalLogManager;
+
+mod remote_logs;
+pub use crate::remote_logs::RemoteLogsManager;

--- a/xactserver/src/local_log.rs
+++ b/xactserver/src/local_log.rs
@@ -1,43 +1,193 @@
-use bytes::{Buf, Bytes};
-use std::sync::{Arc, Mutex};
-use tokio::sync::mpsc;
+use bytes::Bytes;
+use log::{error, info};
+use std::sync::{Arc, RwLock};
+use tokio::sync::{mpsc, watch};
+use tokio::task::JoinHandle;
+use tokio_stream::wrappers::ReceiverStream;
+use tonic::transport::Server;
+use tonic::{Request, Response, Status};
+
+mod proto {
+    tonic::include_proto!("xactserver");
+}
+use proto::log_replication_server::{LogReplication, LogReplicationServer};
+use proto::{LogEntry, Subscription};
 
 /// A `LocalLogManager` receives transactions from the postgres backends in the [`PgWatcher`]
-/// and appends them to the local log.
-///
+/// and appends them to the local log. It also exposes a subscription server to which other
+/// peer servers can subscribe for the log.
+/// 
 /// [`PgWatcher`]: crate::PgWatcher
 ///
 pub struct LocalLogManager {
-    xact_log: Arc<Mutex<XactLog>>,
+    xact_log: Arc<RwLock<XactLog>>,
+    addr: String,
 }
 
 impl LocalLogManager {
-    pub fn new() -> LocalLogManager {
+    pub fn new(addr: &str) -> LocalLogManager {
         LocalLogManager {
-            xact_log: Arc::new(Mutex::new(XactLog::new())),
+            xact_log: Arc::new(RwLock::new(XactLog::new())),
+            addr: addr.to_owned(),
         }
     }
 
-    pub fn thread_main(&self, mut local_log_rx: mpsc::Receiver<Bytes>) -> anyhow::Result<()> {
+    pub fn thread_main(&self, pg_chan: mpsc::Receiver<Bytes>) -> anyhow::Result<()> {
         let rt = tokio::runtime::Builder::new_current_thread()
+            .worker_threads(1)
+            .enable_all()
             .build()
             .unwrap();
 
-        let xact_log = Arc::clone(&self.xact_log);
         rt.block_on(async move {
-            while let Some(mut buf) = local_log_rx.recv().await {
-                // TODO: The xact_log is wrapped in a mutex because it will be shared by
-                // different asynchronous tasks responsible for log replication
-                let mut log = xact_log.lock().unwrap();
-                log.append(buf.to_vec());
+            // TODO: this channel is only used for signaling for now. The data sent through
+            // the channel is ignored, but it can be used to carry extra information later.
+            let (log_appended_tx, log_appended_rx) = watch::channel(1);
 
-                while let Some(tup) = get_tuple(&mut buf) {
-                    println!("{:?}", tup);
-                }
+            let log_management_task = self.get_log_management_task(pg_chan, log_appended_tx);
+            let replication_task = self.get_replication_task(log_appended_rx);
+            let (log_management_task_res, replication_task_res) =
+                tokio::try_join!(log_management_task, replication_task).unwrap();
+
+            if let Err(e) = log_management_task_res {
+                error!("\"log management task\" exited with error: {}", e);
+            }
+
+            if let Err(e) = replication_task_res {
+                error!("\"replication task\" exited with error: {}", e);
             }
         });
 
         Ok(())
+    }
+
+    fn get_log_management_task(
+        &self,
+        mut pg_chan: mpsc::Receiver<Bytes>,
+        xact_log_appended: watch::Sender<i32>,
+    ) -> JoinHandle<anyhow::Result<()>> {
+        let xact_log = Arc::clone(&self.xact_log);
+
+        tokio::spawn(async move {
+            // Continuously listen for new transactions from the postgres watcher
+            while let Some(buf) = pg_chan.recv().await {
+                let mut xact_log = xact_log.write().unwrap();
+
+                xact_log.append(buf.to_vec());
+
+                // Notify all replication tasks about the new transaction
+                xact_log_appended.send(1)?
+            }
+            Ok(())
+        })
+    }
+
+    fn get_replication_task(
+        &self,
+        xact_log_appended: watch::Receiver<i32>,
+    ) -> JoinHandle<anyhow::Result<()>> {
+        let svc = LogReplicationServer::new(LogReplicationHandler::new(
+            Arc::clone(&self.xact_log),
+            xact_log_appended,
+        ));
+        let addr = self.addr.clone();
+
+        tokio::spawn(async move {
+            info!("local log replication server listens on {}", addr);
+            Server::builder()
+                .add_service(svc)
+                .serve(addr.parse()?)
+                .await?;
+            Ok(())
+        })
+    }
+}
+
+struct LogReplicationHandler {
+    xact_log: Arc<RwLock<XactLog>>,
+    xact_log_appended: watch::Receiver<i32>,
+}
+
+impl LogReplicationHandler {
+    fn new(
+        xact_log: Arc<RwLock<XactLog>>,
+        xact_log_appended: watch::Receiver<i32>,
+    ) -> LogReplicationHandler {
+        LogReplicationHandler {
+            xact_log,
+            xact_log_appended,
+        }
+    }
+
+    // This function runs in a dedicated asynchronous task. Whenever a new log entry is appended
+    // to the local log, the log management task sends a signal to this task, upon which this task
+    // wakes up and streams new log entries to the remote subscribers.
+    async fn replicate_xact_log(
+        request: Request<Subscription>,
+        xact_log: Arc<RwLock<XactLog>>,
+        mut xact_log_appended: watch::Receiver<i32>,
+        stream: mpsc::Sender<Result<LogEntry, Status>>,
+    ) {
+        let remote_addr = request
+            .remote_addr()
+            .map_or("[none]".into(), |a| a.to_string());
+
+        loop {
+            // Wake up when there is a new transaction appended to the log or when the
+            // stream is closed by the subscriber.
+            tokio::select! {
+                res = xact_log_appended.changed() => {
+                    // This happens when the sender side of xact_log_appended is closed
+                    if res.is_err() {
+                        break;
+                    }
+
+                    // TODO: send the tail of the log to the subscriber for now. What should
+                    // happen is that we send from the point requested by the subscriber
+                    let log_entry = {
+                        let xact_log = xact_log.read().unwrap();
+                        xact_log.tail().and_then(
+                            |data| Some(LogEntry { data: data.clone() }
+                        ))
+                    };
+
+                    // Send the log entry to the subscriber
+                    if let Some(log_entry) = log_entry {
+                        if let Err(e) = stream.send(Ok(log_entry)).await {
+                            error!("failed to replicate log entry to {}: {}", remote_addr, e);
+                            break;
+                        }
+                    }
+                }
+                _ = stream.closed() => {
+                    break;
+                }
+            }
+        }
+        info!("connection to {} was closed", remote_addr);
+    }
+}
+
+#[tonic::async_trait]
+impl LogReplication for LogReplicationHandler {
+    type SubscribeStream = ReceiverStream<Result<LogEntry, Status>>;
+
+    async fn subscribe(
+        &self,
+        request: Request<Subscription>,
+    ) -> Result<Response<Self::SubscribeStream>, Status> {
+        let (stream_tx, stream_rx) = mpsc::channel(100);
+
+        // Spawn a long running task to continuously send local log entries
+        // to the subscriber
+        tokio::spawn(Self::replicate_xact_log(
+            request,
+            Arc::clone(&self.xact_log),
+            self.xact_log_appended.clone(),
+            stream_tx,
+        ));
+
+        Ok(Response::new(ReceiverStream::new(stream_rx)))
     }
 }
 
@@ -53,16 +203,8 @@ impl XactLog {
     pub fn append(&mut self, entry: Vec<u8>) {
         self.log.push(entry)
     }
-}
 
-fn get_tuple(buf: &mut Bytes) -> Option<(i32, i32, i32, i16)> {
-    if buf.remaining() == 0 {
-        return None;
+    pub fn tail(&self) -> Option<&Vec<u8>> {
+        self.log.last()
     }
-    let dbid = buf.get_i32();
-    let rid = buf.get_i32();
-    let blockno = buf.get_i32();
-    let offset = buf.get_i16();
-
-    Some((dbid, rid, blockno, offset))
 }

--- a/xactserver/src/remote_logs.rs
+++ b/xactserver/src/remote_logs.rs
@@ -69,7 +69,7 @@ impl RemoteLogsManager {
                         }
                     }
                 }
-                
+
                 sleep(Duration::from_secs(1)).await;
             }
         })

--- a/xactserver/src/remote_logs.rs
+++ b/xactserver/src/remote_logs.rs
@@ -1,0 +1,89 @@
+use bytes::{Buf, Bytes};
+use log::{error, info};
+use tokio::task::JoinHandle;
+use tokio::time::{sleep, Duration};
+
+mod proto {
+    tonic::include_proto!("xactserver");
+}
+use proto::log_replication_client::LogReplicationClient;
+use proto::Subscription;
+
+/// A `RemoteLogsManager` subscribes to all peer servers to receives their transaction logs.
+pub struct RemoteLogsManager {
+    peers: Vec<String>,
+}
+
+impl RemoteLogsManager {
+    pub fn new(peers: Vec<&str>) -> RemoteLogsManager {
+        RemoteLogsManager {
+            peers: peers.iter().map(|s| (*s).to_owned()).collect(),
+        }
+    }
+
+    pub fn thread_main(&self) -> anyhow::Result<()> {
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .enable_all()
+            .build()
+            .unwrap();
+
+        rt.block_on(async {
+            let mut tasks = vec![];
+            // Create a log management task for each peer
+            for p in &self.peers {
+                tasks.push(self.get_log_management_task(p));
+            }
+            let tasks_res = futures::future::join_all(tasks).await;
+            for res in tasks_res {
+                if let Err(e) = res.unwrap() {
+                    error!("task exited with error: {}", e);
+                }
+            }
+        });
+
+        Ok(())
+    }
+
+    fn get_log_management_task(&self, peer: &str) -> JoinHandle<anyhow::Result<()>> {
+        let peer = peer.to_owned();
+
+        tokio::spawn(async move {
+            let peer = peer;
+            loop {
+                info!("trying to connect to {}", peer);
+                let client = LogReplicationClient::connect(peer.clone()).await;
+
+                if let Ok(mut client) = client {
+                    let stream = client.subscribe(Subscription {}).await;
+
+                    if let Ok(stream) = stream {
+                        info!("subscribed to transaction log on {}", peer);
+                        let mut stream = stream.into_inner();
+
+                        while let Ok(Some(log_entry)) = stream.message().await {
+                            let mut data = Bytes::from(log_entry.data);
+                            while let Some(tup) = get_tuple(&mut data) {
+                                println!("{:?}", tup);
+                            }
+                        }
+                    }
+                }
+                
+                sleep(Duration::from_secs(1)).await;
+            }
+        })
+    }
+}
+
+fn get_tuple(buf: &mut Bytes) -> Option<(i32, i32, i32, i16)> {
+    if buf.remaining() == 0 {
+        return None;
+    }
+    let dbid = buf.get_i32();
+    let rid = buf.get_i32();
+    let blockno = buf.get_i32();
+    let offset = buf.get_i16();
+
+    Some((dbid, rid, blockno, offset))
+}


### PR DESCRIPTION
+ Add a subscription server in local log manager
+ A remote logs manager subscribes to log of all peers

**How to test**
Start 3 servers on 3 different terminals
```
$ target/debug/xactserver
[2021-11-08T18:04:23Z INFO  xactserver::pg_watch] watching postgres on 127.0.0.1:8888
[2021-11-08T18:04:23Z INFO  xactserver::local_log] local log replication server listens on 127.0.0.1:10000
```
```
$ target/debug/xactserver --listen-pg 127.0.0.1:8889 --listen-peer 127.0.0.1:10001 --peers http://127.0.0.1:10000
[2021-11-08T18:07:15Z INFO  xactserver::pg_watch] watching postgres on 127.0.0.1:8889
[2021-11-08T18:07:15Z INFO  xactserver::local_log] local log replication server listens on 127.0.0.1:10001
[2021-11-08T18:07:15Z INFO  xactserver::remote_logs] trying to connect to http://127.0.0.1:10000
[2021-11-08T18:07:15Z INFO  xactserver::remote_logs] subscribed to transaction log on http://127.0.0.1:10000
```
```
target/debug/xactserver --listen-pg 127.0.0.1:8890 --listen-peer 127.0.0.1:10002 --peers http://127.0.0.1:10000
[2021-11-08T18:07:20Z INFO  xactserver::pg_watch] watching postgres on 127.0.0.1:8890
[2021-11-08T18:07:20Z INFO  xactserver::local_log] local log replication server listens on 127.0.0.1:10002
[2021-11-08T18:07:20Z INFO  xactserver::remote_logs] trying to connect to http://127.0.0.1:10000
[2021-11-08T18:07:20Z INFO  xactserver::remote_logs] subscribed to transaction log on http://127.0.0.1:10000
```

Start postgres and run the queries as in https://github.com/poojanilangekar/Slogora/pull/2. The transaction data will be sent to the server in the first terminal and replicated to the other 2 servers:
```
$ target/debug/xactserver --listen-pg 127.0.0.1:8889 --listen-peer 127.0.0.1:10001 --peers http://127.0.0.1:10000
...
[2021-11-08T18:07:15Z INFO  xactserver::remote_logs] subscribed to transaction log on http://127.0.0.1:10000
(12757, 16392, 1, -1)
(12757, 16389, 0, 2)
(12757, 16389, 0, 3)
(12757, 16389, 0, 4)
```
```
target/debug/xactserver --listen-pg 127.0.0.1:8890 --listen-peer 127.0.0.1:10002 --peers http://127.0.0.1:10000
...
[2021-11-08T18:07:20Z INFO  xactserver::remote_logs] subscribed to transaction log on http://127.0.0.1:10000
(12757, 16392, 1, -1)
(12757, 16389, 0, 2)
(12757, 16389, 0, 3)
(12757, 16389, 0, 4)
```

Now try to stop the first server with Ctrl-C. The other 2 servers will try to reconnect to the first server periodically. After starting the first server again, that 2 servers will reconnect successfully.


