### PR TITLE
Define new config variable for connection string

### DIFF
--- a/postgres/src/backend/access/transam/remotexact_default.c
+++ b/postgres/src/backend/access/transam/remotexact_default.c
@@ -20,7 +20,7 @@ default_collect_seq_scan_rel_id(Relation relation)
 {
 }
 
-static void 
+static void
 default_collect_index_scan_page_id(Relation relation, BlockNumber blkno)
 {
 }

--- a/postgres/src/include/access/remotexact.h
+++ b/postgres/src/include/access/remotexact.h
@@ -16,7 +16,7 @@ typedef struct
 {
 	void		(*collect_read_tid) (Relation relation, ItemPointer tid, TransactionId tuple_xid);
 	void		(*collect_seq_scan_rel_id) (Relation relation);
-	void 		(*collect_index_scan_page_id) (Relation relation, BlockNumber blkno);
+	void		(*collect_index_scan_page_id) (Relation relation, BlockNumber blkno);
 	void		(*clear_rwset) (void);
 	void		(*send_rwset_and_wait) (void);
 } RemoteXactHook;

--- a/xactserver/src/bin/xactserver.rs
+++ b/xactserver/src/bin/xactserver.rs
@@ -28,8 +28,8 @@ fn main() -> anyhow::Result<()> {
         )
         .get_matches();
 
-    let listen_pg = args.value_of("listen-pg").unwrap_or("127.0.0.1:8888");
-    let listen_peer = args.value_of("listen-peer").unwrap_or("127.0.0.1:10000");
+    let listen_pg = args.value_of("listen-pg").unwrap_or("127.0.0.1:10000");
+    let listen_peer = args.value_of("listen-peer").unwrap_or("127.0.0.1:23000");
     let peers = args.values_of("peers").unwrap_or_default().collect();
 
     // Create log managers


### PR DESCRIPTION
Add a new config variable so that we can modify the connection string. 

With this change, we can test the following set up.

## Start node 1
Initialize the database:
```
mkdir -p $HOME/data/postgresql-1
PGDATA=$HOME/data/postgresql-1 tmp_install/bin/initdb
```

In two different terminals, run:
```
$ target/debug/xactserver --peers http://127.0.0.1:23001,http://127.0.0.1:23002
```
```
$ PGDATA=$HOME/data/postgresql-1 postgres -c shared_preload_libraries=remotexact
```

## Start node 2
Initialize the database:
```
mkdir -p $HOME/data/postgresql-2
PGDATA=$HOME/data/postgresql-2 tmp_install/bin/initdb
```

In two different terminals, run:
```
$ target/debug/xactserver --listen-pg 127.0.0.1:10001 --listen-peer 127.0.0.1:23001 --peers http://127.0.0.1:23000,http://127.0.0.1:23002
```
```
$ PGDATA=$HOME/data/postgresql-2 postgres -c shared_preload_libraries=remotexact  -c remotexact.connstring=postgresql://127.0.0.1:10001 -c port=5433
```

## Start node 3
This node only subscribes to the 2 previous nodes:
```
$ target/debug/xactserver --listen-pg 127.0.0.1:10002 --listen-peer 127.0.0.1:23002 --peers http://127.0.0.1:23000,http://127.0.0.1:23001
```

## Send query to node 1
Note that there is no need to load the shared library because we already did it in the command line arguments.
```
$ psql -d postgres
set enable_seqscan=off;
create table tbl(a int, b int);
create index on tbl (b);
insert into tbl values(1, 10);
insert into tbl values(2, 20);
insert into tbl values(3, 20);
insert into tbl values(4, 20);
begin transaction isolation level serializable;
select * from tbl where b = 20;
commit;
```
You should see the tuples being printed on node 2 and node 3

## Send query to node 2
Connect to node 2 with
```
$ psql -d postgres -p 5433
```
Send the same queries as above. You should see the tuples being printed on node 1 and node 3.
