### PR TITLE
Organize read/write set into a proper format

### DIFF
--- a/postgres/contrib/remotexact/remotexact.c
+++ b/postgres/contrib/remotexact/remotexact.c
@@ -192,7 +192,7 @@ rx_send_rwset_and_wait(void)
 	pq_sendint32(&buf, header->dbid);
 	pq_sendint32(&buf, header->xid);
 
-	/* Cursor now points to where the read section length is stored */
+	/* Cursor now points to where the length of the read section is stored */
 	buf.cursor = buf.len;
 	/* Read section length will be updated later */
 	pq_sendint32(&buf, 0);
@@ -220,13 +220,14 @@ rx_send_rwset_and_wait(void)
 		}
 
 		pq_sendbytes(&buf, items->data, items->len);
+
 		readLen += buf.len;
 	}
 
-	/* Update read section length in the buffer */
+	/* Update the length of the read section */
 	*(int *) (buf.data + buf.cursor) = pg_hton32(readLen);
 
-	/* Send the buffer to the xact server */
+	/* Actually send the buffer to the xact server */
 	if (PQputCopyData(XactServerConn, buf.data, buf.len) <= 0 || PQflush(XactServerConn))
 	{
 		ereport(WARNING, errmsg("[remotexact] failed to send read/write set"));

--- a/postgres/src/backend/access/transam/remotexact_default.c
+++ b/postgres/src/backend/access/transam/remotexact_default.c
@@ -11,17 +11,17 @@
 #include "access/remotexact.h"
 
 static void
-default_collect_read_tid(Relation relation, ItemPointer tid, TransactionId tuple_xid)
+default_collect_read_tuple(Relation relation, ItemPointer tid, TransactionId tuple_xid)
 {
 }
 
 static void
-default_collect_seq_scan_rel_id(Relation relation)
+default_collect_seq_scan_relation(Relation relation)
 {
 }
 
 static void
-default_collect_index_scan_page_id(Relation relation, BlockNumber blkno)
+default_collect_index_scan_page(Relation relation, BlockNumber blkno)
 {
 }
 
@@ -36,14 +36,14 @@ default_send_rwset_and_wait(void)
 }
 
 static const RemoteXactHook default_hook = {
-	.collect_read_tid = default_collect_read_tid,
-	.collect_seq_scan_rel_id = default_collect_seq_scan_rel_id,
-	.collect_index_scan_page_id = default_collect_index_scan_page_id,
+	.collect_read_tuple = default_collect_read_tuple,
+	.collect_seq_scan_relation = default_collect_seq_scan_relation,
+	.collect_index_scan_page = default_collect_index_scan_page,
 	.clear_rwset = default_clear_rwset,
 	.send_rwset_and_wait = default_send_rwset_and_wait
 };
 
-static RemoteXactHook *remote_xact_hook = &default_hook;
+static const RemoteXactHook *remote_xact_hook = &default_hook;
 
 void
 SetRemoteXactHook(const RemoteXactHook *hook)
@@ -52,8 +52,14 @@ SetRemoteXactHook(const RemoteXactHook *hook)
 	remote_xact_hook = hook;
 }
 
-RemoteXactHook *
+const RemoteXactHook *
 GetRemoteXactHook(void)
 {
 	return remote_xact_hook;
+}
+
+void
+AtEOXact_RemoteXact(void)
+{
+	remote_xact_hook->clear_rwset();
 }

--- a/postgres/src/backend/storage/lmgr/predicate.c
+++ b/postgres/src/backend/storage/lmgr/predicate.c
@@ -2579,7 +2579,7 @@ PredicateLockRelation(Relation relation, Snapshot snapshot)
 										relation->rd_id);
 	PredicateLockAcquire(&tag);
 
-	GetRemoteXactHook()->collect_seq_scan_rel_id(relation);
+	GetRemoteXactHook()->collect_seq_scan_relation(relation);
 }
 
 /*
@@ -2605,7 +2605,7 @@ PredicateLockPage(Relation relation, BlockNumber blkno, Snapshot snapshot)
 									blkno);
 	PredicateLockAcquire(&tag);
 
-	GetRemoteXactHook()->collect_index_scan_page_id(relation, blkno);
+	GetRemoteXactHook()->collect_index_scan_page(relation, blkno);
 }
 
 /*
@@ -2653,7 +2653,7 @@ PredicateLockTID(Relation relation, ItemPointer tid, Snapshot snapshot,
 									 ItemPointerGetOffsetNumber(tid));
 	PredicateLockAcquire(&tag);
 
-	GetRemoteXactHook()->collect_read_tid(relation, tid, tuple_xid);
+	GetRemoteXactHook()->collect_read_tuple(relation, tid, tuple_xid);
 }
 
 

--- a/postgres/src/include/access/remotexact.h
+++ b/postgres/src/include/access/remotexact.h
@@ -14,14 +14,16 @@
 
 typedef struct
 {
-	void		(*collect_read_tid) (Relation relation, ItemPointer tid, TransactionId tuple_xid);
-	void		(*collect_seq_scan_rel_id) (Relation relation);
-	void		(*collect_index_scan_page_id) (Relation relation, BlockNumber blkno);
+	void		(*collect_read_tuple) (Relation relation, ItemPointer tid, TransactionId tuple_xid);
+	void		(*collect_seq_scan_relation) (Relation relation);
+	void		(*collect_index_scan_page) (Relation relation, BlockNumber blkno);
 	void		(*clear_rwset) (void);
 	void		(*send_rwset_and_wait) (void);
 } RemoteXactHook;
 
 extern void SetRemoteXactHook(const RemoteXactHook *hook);
-extern RemoteXactHook *GetRemoteXactHook(void);
+extern const RemoteXactHook *GetRemoteXactHook(void);
+
+extern void AtEOXact_RemoteXact(void);
 
 #endif							/* REMOTEXACT_H */

--- a/postgres/src/tools/pgindent/typedefs.list
+++ b/postgres/src/tools/pgindent/typedefs.list
@@ -2097,7 +2097,10 @@ RTEKind
 RWConflict
 RWConflictPoolHeader
 RWSet
-RWSetData
+RWSetPtr
+RWSetHeader
+RWSetReadRelation
+RWSetReadRelationKey
 RandomState
 Range
 RangeBound

--- a/xactserver/src/lib.rs
+++ b/xactserver/src/lib.rs
@@ -6,3 +6,5 @@ pub use crate::local_log::LocalLogManager;
 
 mod remote_logs;
 pub use crate::remote_logs::RemoteLogsManager;
+
+pub mod transaction;

--- a/xactserver/src/transaction.rs
+++ b/xactserver/src/transaction.rs
@@ -1,0 +1,187 @@
+use anyhow::{bail, Context};
+use bytes::{Buf, Bytes};
+use std::mem::size_of;
+
+type Oid = u32;
+
+#[derive(Debug)]
+pub struct Transaction {
+    dbid: Oid,
+    xid: u32,
+    relations: Vec<Relation>,
+}
+
+impl Transaction {
+    pub fn parse(buf: &mut Bytes) -> anyhow::Result<Transaction> {
+        const HEADER_SZ: usize = size_of::<Oid>() + size_of::<u32>() + size_of::<u32>();
+
+        if buf.remaining() < HEADER_SZ {
+            bail!(
+                "header too short, expected: {}, remaining: {}",
+                HEADER_SZ,
+                buf.remaining()
+            );
+        }
+        let dbid = buf.get_u32();
+        let xid = buf.get_u32();
+        let readlen = buf.get_u32() as usize;
+
+        if buf.remaining() < readlen {
+            bail!(
+                "read section too short, expected: {}, remaining: {}",
+                readlen,
+                buf.remaining()
+            );
+        }
+        let mut readbuf = buf.split_to(readlen);
+        let mut relations = vec![];
+        let mut i = 0;
+        while readbuf.has_remaining() {
+            let ctx = || {
+                let i = i;
+                format!(
+                    "failed to parse relation {} [dbid: {}, xid: {}, readlen: {}]",
+                    i, dbid, xid, readlen
+                )
+            };
+            let r = Relation::parse(&mut readbuf).with_context(ctx)?;
+            relations.push(r);
+            i += 1;
+        }
+
+        Ok(Transaction {
+            dbid,
+            xid,
+            relations,
+        })
+    }
+}
+
+#[derive(Debug)]
+pub enum Relation {
+    Table {
+        oid: u32,
+        csn: u32,
+        tuples: Vec<Tuple>,
+    },
+    Index {
+        oid: u32,
+        pages: Vec<Page>,
+    },
+}
+
+#[derive(Debug)]
+pub struct Tuple {
+    blocknum: u32,
+    offset: u16,
+}
+
+#[derive(Debug)]
+pub struct Page {
+    blocknum: u32,
+    csn: u32,
+}
+
+impl Relation {
+    pub fn parse(buf: &mut Bytes) -> anyhow::Result<Relation> {
+        let rel_type = buf.get_u8();
+        match rel_type {
+            b'T' => Relation::parse_table(buf),
+            b'I' => Relation::parse_index(buf),
+            _ => bail!("invalid relation type: {}", rel_type),
+        }
+    }
+
+    fn parse_table(buf: &mut Bytes) -> anyhow::Result<Relation> {
+        const TABLE_HEADER_SZ: usize = size_of::<Oid>() + size_of::<u32>() + size_of::<u32>();
+
+        if buf.remaining() < TABLE_HEADER_SZ {
+            bail!(
+                "table header length too short, expected: {}, remaining: {}",
+                TABLE_HEADER_SZ,
+                buf.remaining()
+            );
+        }
+        let relid = buf.get_u32();
+        let ntuples = buf.get_u32();
+        let csn = buf.get_u32();
+        let mut tuples = vec![];
+        for i in 0..ntuples {
+            let ctx = || {
+                let i = i;
+                format!(
+                    "failed to parse tuple {} in Table(relid: {}, ntuples: {}, csn: {})",
+                    i, relid, ntuples, csn
+                )
+            };
+            let t = Relation::parse_tuple(buf).with_context(ctx)?;
+            tuples.push(t);
+        }
+
+        Ok(Relation::Table {
+            oid: relid,
+            csn,
+            tuples,
+        })
+    }
+
+    fn parse_tuple(buf: &mut Bytes) -> anyhow::Result<Tuple> {
+        const TUPLE_SZ: usize = size_of::<u32>() + size_of::<u16>();
+
+        if buf.remaining() < TUPLE_SZ {
+            bail!(
+                "tuple too short, expected: {}, remaining: {}",
+                TUPLE_SZ,
+                buf.remaining()
+            );
+        }
+        let blocknum = buf.get_u32();
+        let offset = buf.get_u16();
+
+        Ok(Tuple { blocknum, offset })
+    }
+
+    fn parse_index(buf: &mut Bytes) -> anyhow::Result<Relation> {
+        const INDEX_HEADER_SZ: usize = size_of::<Oid>() + size_of::<u32>();
+
+        if buf.remaining() < INDEX_HEADER_SZ {
+            bail!(
+                "table header length too short, expected: {}, remaining: {}",
+                INDEX_HEADER_SZ,
+                buf.remaining()
+            );
+        }
+        let relid = buf.get_u32();
+        let npages = buf.get_u32();
+        let mut pages = vec![];
+        for i in 0..npages {
+            let ctx = || {
+                let i = i;
+                format!(
+                    "failed to parse page {} in Index(relid: {}, npages: {})",
+                    i, relid, npages
+                )
+            };
+            let p = Relation::parse_page(buf).with_context(ctx)?;
+            pages.push(p);
+        }
+
+        Ok(Relation::Index { oid: relid, pages })
+    }
+
+    fn parse_page(buf: &mut Bytes) -> anyhow::Result<Page> {
+        const PAGE_SZ: usize = size_of::<u32>() + size_of::<u32>();
+
+        if buf.remaining() < PAGE_SZ {
+            bail!(
+                "page too short, expected: {}, remaining: {}",
+                PAGE_SZ,
+                buf.remaining()
+            );
+        }
+        let blocknum = buf.get_u32();
+        let csn = buf.get_u32();
+
+        Ok(Page { blocknum, csn })
+    }
+}


### PR DESCRIPTION
Use a hash map to track the read of the relations. At commit time, serialize that data following [this format](https://github.com/poojanilangekar/Slogora/wiki/Message-format) before sending to the transaction server.

The transaction server doesn't have to parse this data but code to parsing it is provided to test that serialization is working.

Example run:

Start the transaction server
```
$ target/debug/xactserver
```

Start postgres
```
$ tmp_install/bin/postgres -p 10000 -c shared_preload_libraries=remotexact
```

Run query
```
$ tmp_install/bin/psql -p 10000 -d postgres
create table tbl(a int, b int);
create index on tbl (b);
insert into tbl values(1, 10);
insert into tbl values(2, 20);
insert into tbl values(3, 20);
insert into tbl values(4, 20);
begin transaction isolation level serializable;
select * from tbl where b = 20;
commit;
```

The transaction server terminal should show
```
[2021-11-21T04:05:25Z INFO  xactserver::local_log] received
    Transaction {
        dbid: 12757,
        xid: 0,
        relations: [
            Index {
                oid: 16452,
                pages: [
                    Page {
                        blocknum: 1,
                        csn: 1,
                    },
                ],
            },
            Table {
                oid: 16449,
                csn: 0,
                tuples: [
                    Tuple {
                        blocknum: 0,
                        offset: 2,
                    },
                    Tuple {
                        blocknum: 0,
                        offset: 3,
                    },
                    Tuple {
                        blocknum: 0,
                        offset: 4,
                    },
                ],
            },
        ],
    }

```
